### PR TITLE
Using return values in empty() is a PHP 5.5 only thing.

### DIFF
--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -47,7 +47,8 @@ class UserRepository {
             'username' => $user->username,
         ];
 
-        if (!empty(array_diff($socialData, $dbData))) {
+        $diff = array_diff($socialData, $dbData);
+        if (!empty($diff)) {
             $user->avatar = $userData->avatar;
             $user->email = $userData->email;
             $user->name = $userData->name;


### PR DESCRIPTION
Now works in PHP versions other than 5.5